### PR TITLE
Improve clustering and basic security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,28 @@
-FROM       mini/java
-MAINTAINER Luis Lavena <luislavena@gmail.com>
+FROM gliderlabs/alpine:3.3
+
+ENV JAVA_VERSION 8.66.17-r2
+
+RUN apk add --no-cache openjdk8-jre-base=$JAVA_VERSION pwgen
 
 ENV ELASTICSEARCH_VERSION 1.7.5
 
 RUN \
+  apk add --no-cache --virtual .install-tools wget && \
   mkdir -p /opt && \
   cd /tmp && \
   wget --progress=dot:mega https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
   tar -xzf elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
   rm -rf elasticsearch-$ELASTICSEARCH_VERSION.tar.gz && \
-  mv elasticsearch-$ELASTICSEARCH_VERSION /opt/elasticsearch
+  mv elasticsearch-$ELASTICSEARCH_VERSION /opt/elasticsearch && \
+  apk del --virtual .install-tools
 
-ADD ./config/elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml
-ADD ./scripts/start.sh /start.sh
+ENV ES_HTTP_BASIC_VERSION 1.5.1
+
+RUN \
+  /opt/elasticsearch/bin/plugin --install http-basic --url https://github.com/Asquera/elasticsearch-http-basic/releases/download/v$ES_HTTP_BASIC_VERSION/elasticsearch-http-basic-$ES_HTTP_BASIC_VERSION.jar
+
+COPY ./config/elasticsearch.yml /opt/elasticsearch/config/elasticsearch.yml
+COPY ./scripts/start.sh /start.sh
 
 VOLUME ["/data"]
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ You can now check the logs:
 docker logs <CONTAINER_ID>
 ```
 
+You can also control the HTTP transport port to be something other than
+`9200`, simply use `ELASTICSEARCH_PORT` and ensure the one given matches
+the one being exposed by Docker.
+
 Note that port `9300` (tcp) is also exposed, but is not required unless you
 want to build a multi-node cluster using this container :wink:
 
@@ -30,6 +34,35 @@ docker run -v /mydata/elasticsearch:/data -d -p 9200:9200 mini/elasticsearch
 
 We recommend you mount the volume to avoid loosing data between updates to
 the container.
+
+## Basic Authentication
+
+While is not a strong security mechanism, Asquera's [http-basic](https://github.com/Asquera/elasticsearch-http-basic) plugin has been added to avoid pesky eyes to your
+Elasticsearch installation.
+
+Define `ELASTICSEARCH_AUTH=yes` to the container's environment and will enable
+default credentials. Default username is `elastic`.
+
+You can adjust both username and password by setting `ELASTICSEARCH_USER` and
+`ELASTICSEARCH_PASS` respectively.
+
+**Important**: If no password is defined, the container will generate one
+randomly on each start. You can inspect the container logs for the generated
+password but is strongly recommended you set one by using the environment
+variables described above.
+
+## Cluster and Node identification
+
+For development purposes, both cluster and node names might be irrelevant, so
+Elasticsearch's default behavior might be OK.
+
+However, moving to a production environment, it is desired to control these
+two options in order to ensure multiple instances running on the same cluster
+are setup independently.
+
+Use `ELASTICSEARCH_CLUSTER` and `ELASTICSEARCH_NODE` variables to define
+which cluster name will use for discovery and which name will be used for
+announcement to such cluster.
 
 ## Sponsor
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -6,6 +6,11 @@ network:
 http:
   port: 9200
 
+# Basic Authentication
+  basic:
+    enabled: false
+    log: false
+
 transport:
   tcp:
     port: 9300

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,13 +1,75 @@
 #!/bin/sh
 
-local ELASTICSEARCH_YML="/opt/elasticsearch/config/elasticsearch.yml"
+local ES_YML="/opt/elasticsearch/config/elasticsearch.yml"
+local ES_OPTS="-Des.config=$ES_YML"
+local ES_HTTP_PORT="9200"
+
+set_authentication() {
+	local _use_auth=${ELASTICSEARCH_AUTH:-"no"}
+
+	if [ ${_use_auth} == "yes" ]; then
+		# use default user if none is provided
+		local _username=${ELASTICSEARCH_USER:-"elastic"}
+
+		# use provided password or generate a random one
+		local _pass=${ELASTICSEARCH_PASS:-$(pwgen -s 22 1)}
+		local _type=$( [ ${ELASTICSEARCH_PASS} ] && echo "defined" || echo "generated" )
+
+		echo "=> Enable HTTP Basic Authentication..."
+		ES_OPTS="$ES_OPTS -Des.http.basic.enabled=true -Des.http.basic.user=${_username} -Des.http.basic.password=${_pass}"
+
+		echo "======================================================================"
+		echo " Use the following URL to connect to this Elasticsearch server:"
+		echo ""
+
+		if [ ${_type} == "generated" ]; then
+			echo "   http://$_username:$_pass@<host>:<port>/"
+			echo ""
+			echo "  !!! IMPORTANT !!!"
+			echo ""
+			echo "  The password shown above is a random one and should be replaced"
+			echo "  by your own using `ELASTICSEARCH_PASS` environment variable."
+			echo ""
+		else
+			echo "   http://$_username:<not shown>@<host>:<port>/"
+			echo ""
+		fi
+
+		echo "======================================================================"
+	fi
+}
+
+set_http_port() {
+	local _http_port=${ELASTICSEARCH_PORT:-"9200"}
+
+	if [ ! "${_http_port}" == "9200" ]; then
+		echo "=> Using port '${_http_port}'"
+		ES_HTTP_PORT="${_http_port}"
+		ES_OPTS="$ES_OPTS -Des.http.port=${_http_port}"
+	fi
+}
+
+set_identification() {
+	local _cluster_name=${ELASTICSEARCH_CLUSTER:-"elasticsearch"}
+	local _node_name=${ELASTICSEARCH_NODE:-"noname"}
+
+	if [ ! "${_cluster_name}" == "elasticsearch" ]; then
+		echo "=> Cluster name is '${_cluster_name}'"
+		ES_OPTS="$ES_OPTS -Des.cluster.name=\"${_cluster_name}\""
+	fi
+
+	if [ ! "${_node_name}" == "noname" ]; then
+		echo "=> Node name is '${_node_name}'"
+		ES_OPTS="$ES_OPTS -Des.node.name=\"${_node_name}\""
+	fi
+}
 
 shutdown() {
 	local pid=$1
 
 	echo "=> Shutdown requested, stopping Elasticsearch..."
 
-	curl --silent -XPOST 'http://localhost:9200/_cluster/nodes/_local/_shutdown' > /dev/null
+	echo -e 'POST /_cluster/nodes/_local/_shutdown HTTP/1.0\r\n\r\n' | nc localhost $ES_HTTP_PORT > /dev/null
 
 	# wait for process to terminate
 	wait $pid
@@ -17,8 +79,12 @@ shutdown() {
 }
 
 start() {
+	set_authentication
+	set_identification
+	set_http_port
+
 	# launch as background process
-	/opt/elasticsearch/bin/elasticsearch -Des.config=$ELASTICSEARCH_YML &
+	/opt/elasticsearch/bin/elasticsearch "$ES_OPTS" &
 
 	local pid=$!
 


### PR DESCRIPTION
The changes present here aims to improve mini/elasticsearch usage in more than development environments.

A few changes that are not directly related to cluster or authentication have been introduced:
- Migrate from mini/base to gliderlabs/alpine:3.3 image (image size reduction and removal of extra layers)
- Switch to OpenJDK 8 instead of version 7.
- No longer rely on `curl` to be installed as part of the image.
- Install things like `wget` in a transitive way.

Now, specific to clustering and authencation, the following changes were introduced:
- Usage of Asquera's http-basic authentication plugin (disabled by default)
- Allow configuration of cluster and node names
- Allow configuration of HTTP transport port

By default, HTTP Basic Authentication is disabled, but can be easily activated by using `ELASTICSEARCH_AUTH` with `yes` value.

The default username is `elastic`, but that can be adjusted using `ELASTICSEARCH_USER` variable.

Important: if a password is not specified via `ELASTICSEARCH_PASS`, a random one will be generated **every** time the container is started. To avoid issues is recommended you supply a password using the environment variable described above.

You can adjust the cluster and node names by using `ELASTICSEARCH_NODE` and `ELASTICSEARCH_NODE` respectively.

This is useful when deploying multiple nodes and clusters on the same infrastructure to avoid confusion caused by zen discovery using nodes aimed to different clusters.

Node name is also useful to better identify the node in the machine that is running instead of default Marvel's character names.

Last but not least, you can use `ELASTICSEARCH_PORT` to adjust any port other than the default `9200` used by Elasticsearch for HTTP connections.
